### PR TITLE
feat: tests para Auth

### DIFF
--- a/Bookmerang.Tests/Auth/AuthControllerTests.cs
+++ b/Bookmerang.Tests/Auth/AuthControllerTests.cs
@@ -1,0 +1,255 @@
+using Moq;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Bookmerang.Api.Services.Interfaces.Auth;
+using Bookmerang.Api.Models.DTOs;
+using Bookmeran.Controllers;
+using Bookmerang.Api.Models.Entities;
+using Bookmerang.Api.Models.Enums;
+using NetTopologySuite.Geometries;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Bookmerang.Tests.Auth;
+
+public class AuthControllerTests
+{
+    private readonly Mock<IAuthService> _mockAuthService;
+    private readonly AuthController _authController;
+
+    public AuthControllerTests()
+    {
+        _mockAuthService = new Mock<IAuthService>();
+        _authController = new AuthController(_mockAuthService.Object);
+    }
+
+    private void SetupControllerContext(string? supabaseId, string? email)
+    {
+        var claims = new List<Claim>();
+        if (supabaseId != null)
+        {
+            claims.Add(new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", supabaseId));
+        }
+        if (email != null)
+        {
+            claims.Add(new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", email));
+        }
+
+        var identity = new ClaimsIdentity(claims, "TestAuthType");
+        var claimsPrincipal = new ClaimsPrincipal(identity);
+
+        _authController.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = claimsPrincipal }
+        };
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnUnauthorized_WhenSupabaseIdIsMissing()
+    {
+        // Arrange
+        SetupControllerContext(null, "test@test.com");
+        var request = new RegisterRequest("newuser", "New User", "photo.jpg", BaseUserType.USER, 0, 0);
+
+        // Act
+        var result = await _authController.Register(request);
+
+        // Assert
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnCreatedAt_WhenUserIsNew()
+    {
+        // Arrange
+        var supabaseId = "new-user-supabase-id";
+        var email = "new@example.com";
+        SetupControllerContext(supabaseId, email);
+
+        var request = new RegisterRequest("newuser", "New User", "photo.jpg", BaseUserType.USER, 0, 0);
+
+        var user = new ProfileDto { Id = Guid.NewGuid(), Username = request.Username };
+        _mockAuthService.Setup(s => s.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<BaseUserType>(), It.IsAny<Point>()))
+            .ReturnsAsync((new BaseUser { Id = user.Id, Username = user.Username, Location = new Point(0,0) }, false));
+
+        // Act
+        var result = await _authController.Register(request);
+
+        // Assert
+        var createdAtActionResult = Assert.IsType<CreatedAtActionResult>(result);
+        Assert.Equal(nameof(AuthController.GetPerfil), createdAtActionResult.ActionName);
+        var returnedDto = Assert.IsType<BaseUserDto>(createdAtActionResult.Value);
+        Assert.Equal(user.Id, returnedDto.Id);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnConflict_WhenUserAlreadyExists()
+    {
+        // Arrange
+        var supabaseId = "existing-user-supabase-id";
+        var email = "existing@example.com";
+        SetupControllerContext(supabaseId, email);
+
+        var request = new RegisterRequest("existinguser", "Existing User", null, BaseUserType.USER, 0, 0);
+
+        _mockAuthService.Setup(s => s.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<BaseUserType>(), It.IsAny<Point>()))
+            .ReturnsAsync(((BaseUser?)null, true));
+
+        // Act
+        var result = await _authController.Register(request);
+
+        // Assert
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal("El usuario ya existe en el sistema.", conflictResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMe_ShouldReturnUnauthorized_WhenSupabaseIdIsMissing()
+    {
+        // Arrange
+        SetupControllerContext(null, null);
+
+        // Act
+        var result = await _authController.GetMe();
+
+        // Assert
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task GetMe_ShouldReturnNotFound_WhenUserNotFound()
+    {
+        // Arrange
+        var supabaseId = "not-found-id";
+        SetupControllerContext(supabaseId, "test@test.com");
+        _mockAuthService.Setup(s => s.GetPerfil(supabaseId)).ReturnsAsync((ProfileDto?)null);
+
+        // Act
+        var result = await _authController.GetMe();
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal("Usuario no encontrado en el sistema.", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMe_ShouldReturnOkWithId_WhenUserExists()
+    {
+        // Arrange
+        var supabaseId = "user-id";
+        var userId = Guid.NewGuid();
+        SetupControllerContext(supabaseId, "user@example.com");
+        var user = new ProfileDto { Id = userId };
+        _mockAuthService.Setup(s => s.GetPerfil(supabaseId)).ReturnsAsync(user);
+
+        // Act
+        var result = await _authController.GetMe();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetPerfil_ShouldReturnOk_WhenProfileExists()
+    {
+        // Arrange
+        var supabaseId = "profile-id";
+        SetupControllerContext(supabaseId, "profile@test.com");
+        var profile = new ProfileDto();
+        _mockAuthService.Setup(s => s.GetPerfil(supabaseId)).ReturnsAsync(profile);
+
+        // Act
+        var result = await _authController.GetPerfil();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(profile, okResult.Value);
+    }
+
+    [Fact]
+    public async Task PatchPerfil_ShouldReturnOk_WhenUpdateSucceeds()
+    {
+        // Arrange
+        var supabaseId = "user-to-update";
+        SetupControllerContext(supabaseId, "test@test.com");
+        var request = new UpdatePerfilRequest("newUsername", "newName", "newPhoto.jpg");
+        var updatedUser = new ProfileDto { Id = Guid.NewGuid(), Username = "newUsername" };
+        _mockAuthService.Setup(s => s.UpdatePerfil(supabaseId, request.Username, request.Name, request.ProfilePhoto)).ReturnsAsync(new BaseUser { Id = updatedUser.Id, Username = updatedUser.Username, Location = new Point(0,0) });
+
+        // Act
+        var result = await _authController.PatchPerfil(request);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedDto = Assert.IsType<BaseUserDto>(okResult.Value);
+        Assert.Equal(updatedUser.Id, returnedDto.Id);
+    }
+
+    [Fact]
+    public async Task PatchEmail_ShouldReturnBadRequest_WhenServiceReturnsError()
+    {
+        // Arrange
+        var supabaseId = "user-patching-email";
+        SetupControllerContext(supabaseId, "test@test.com");
+        var request = new PatchEmailRequest("new@email.com");
+        var errorMessage = "Email already in use.";
+        _mockAuthService.Setup(s => s.PatchEmail(supabaseId, request.NewEmail)).ReturnsAsync(((BaseUser?)null, errorMessage));
+
+        // Act
+        var result = await _authController.PatchEmail(request);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(errorMessage, badRequestResult.Value);
+    }
+
+    [Fact]
+    public async Task DeletePerfil_ShouldReturnOk_WhenDeletionSucceeds()
+    {
+        // Arrange
+        var supabaseId = "user-to-delete";
+        SetupControllerContext(supabaseId, "test@test.com");
+        var deletedUser = new BaseUser
+        {
+            Id = Guid.NewGuid(),
+            SupabaseId = supabaseId,
+            Email = "delete@test.com",
+            Username = "delete-user",
+            Name = "Delete User",
+            ProfilePhoto = "delete.jpg",
+            UserType = BaseUserType.USER,
+            Location = new Point(0, 0) { SRID = 4326 }
+        };
+        _mockAuthService.Setup(s => s.DeletePerfil(supabaseId)).ReturnsAsync(deletedUser);
+
+        // Act
+        var result = await _authController.DeletePerfil();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedDto = Assert.IsType<BaseUserDto>(okResult.Value);
+        Assert.Equal(deletedUser.Id, returnedDto.Id);
+    }
+
+    [Fact]
+    public async Task DeletePerfil_ShouldThrowException_WhenServiceThrowsException()
+    {
+        // Arrange
+        var supabaseId = "user-with-active-exchange";
+        SetupControllerContext(supabaseId, "test@test.com");
+        var exceptionMessage = "Cannot delete user with active exchanges.";
+        _mockAuthService.Setup(s => s.DeletePerfil(supabaseId)).ThrowsAsync(new Exception(exceptionMessage));
+
+        // Act
+        var result = await _authController.DeletePerfil();
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(exceptionMessage, badRequestResult.Value);
+    }
+
+}

--- a/Bookmerang.Tests/Auth/AuthServiceTests.cs
+++ b/Bookmerang.Tests/Auth/AuthServiceTests.cs
@@ -1,0 +1,270 @@
+using Bookmerang.Api.Models.Entities;
+using Bookmerang.Api.Data;
+using Microsoft.EntityFrameworkCore;
+using Bookmerang.Api.Services.Implementation.Auth;
+using Bookmerang.Api.Models.Enums;
+using NetTopologySuite.Geometries;
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace Bookmerang.Tests.Auth;
+
+public class AuthServiceTests
+{
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static AuthService CreateService(AppDbContext db)
+    {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        return new AuthService(db, config);
+    }
+
+    [Fact]
+    public async Task Register_ShouldCreateBaseUser_WhenUserIsNewAndNotRegularUser()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "new-supabase-id";
+        var location = new Point(0, 0) { SRID = 4326 };
+
+        (BaseUser? newUser, bool alreadyExisted) = await service.Register(
+            supabaseId,
+            "new@test.com",
+            "newuser",
+            "New User",
+            "photo.jpg",
+            BaseUserType.ADMIN,
+            location
+        );
+
+        Assert.False(alreadyExisted);
+        Assert.NotNull(newUser);
+        Assert.Equal(supabaseId, newUser.SupabaseId);
+        Assert.Single(db.Users);
+        Assert.Empty(db.RegularUsers);
+        Assert.Empty(db.UserProgresses);
+    }
+
+    [Fact]
+    public async Task Register_ShouldCreateRegularUserAndProgress_WhenUserIsNewAndRegularUser()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "new-regular-user-id";
+        var location = new Point(0, 0) { SRID = 4326 };
+
+        (BaseUser? newUser, bool alreadyExisted) = await service.Register(
+            supabaseId,
+            "new-regular@test.com",
+            "newregular",
+            "New Regular",
+            "photo.jpg",
+            BaseUserType.USER,
+            location
+        );
+
+        Assert.False(alreadyExisted);
+        Assert.NotNull(newUser);
+        Assert.Single(db.Users);
+        Assert.Single(db.RegularUsers);
+        Assert.Single(db.UserProgresses);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnAlreadyExisted_WhenUserExists()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "existing-supabase-id";
+        db.Users.Add(new BaseUser
+        {
+            SupabaseId = supabaseId,
+            Email = "existing@test.com",
+            Username = "existing",
+            Name = "Existing",
+            ProfilePhoto = "photo.jpg",
+            UserType = BaseUserType.USER,
+            Location = new Point(0, 0) { SRID = 4326 }
+        });
+        await db.SaveChangesAsync();
+
+        var location = new Point(0, 0) { SRID = 4326 };
+
+        (BaseUser? newUser, bool alreadyExisted) = await service.Register(
+            supabaseId,
+            "exist@test.com",
+            "exists",
+            "Exists",
+            "",
+            BaseUserType.USER,
+            location
+        );
+
+        Assert.True(alreadyExisted);
+        Assert.Null(newUser);
+        Assert.Single(db.Users);
+    }
+
+    [Fact]
+    public async Task GetPerfil_ShouldReturnNull_WhenUserNotFound()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "not-found-id";
+
+        var profile = await service.GetPerfil(supabaseId);
+
+        Assert.Null(profile);
+    }
+
+    [Fact]
+    public async Task UpdatePerfil_ShouldUpdateFields_WhenUserExists()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "user-to-update";
+        db.Users.Add(new BaseUser
+        {
+            SupabaseId = supabaseId,
+            Email = "old@test.com",
+            Username = "olduser",
+            Name = "Old Name",
+            ProfilePhoto = "old.jpg",
+            UserType = BaseUserType.USER,
+            Location = new Point(0, 0) { SRID = 4326 }
+        });
+        await db.SaveChangesAsync();
+
+        var newUsername = "newuser";
+        var newName = "New Name";
+        var newPhoto = "newphoto.jpg";
+
+        var updatedUser = await service.UpdatePerfil(supabaseId, newUsername, newName, newPhoto);
+
+        Assert.NotNull(updatedUser);
+        Assert.Equal(newUsername, updatedUser.Username);
+        Assert.Equal(newName, updatedUser.Name);
+        Assert.Equal(newPhoto, updatedUser.ProfilePhoto);
+    }
+
+    [Fact]
+    public async Task UpdatePerfil_ShouldIgnoreNullOrWhitespaceFields()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "user-to-update-partial";
+        var originalUsername = "originaluser";
+        var originalName = "Original Name";
+        db.Users.Add(new BaseUser
+        {
+            SupabaseId = supabaseId,
+            Email = "original@test.com",
+            Username = originalUsername,
+            Name = originalName,
+            ProfilePhoto = "original.jpg",
+            UserType = BaseUserType.USER,
+            Location = new Point(0, 0) { SRID = 4326 }
+        });
+        await db.SaveChangesAsync();
+
+        var updatedUser = await service.UpdatePerfil(supabaseId, " ", null, "");
+
+        Assert.NotNull(updatedUser);
+        Assert.Equal(originalUsername, updatedUser.Username);
+        Assert.Equal(originalName, updatedUser.Name);
+    }
+
+    [Fact]
+    public async Task PatchEmail_ShouldFail_WhenEmailIsInUse()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var supabaseId = "user-patching-email";
+        db.Users.AddRange(
+            new BaseUser
+            {
+                SupabaseId = supabaseId,
+                Email = "old@email.com",
+                Username = "user1",
+                Name = "User 1",
+                ProfilePhoto = "u1.jpg",
+                UserType = BaseUserType.USER,
+                Location = new Point(0, 0) { SRID = 4326 }
+            },
+            new BaseUser
+            {
+                SupabaseId = "other-user",
+                Email = "new@email.com",
+                Username = "user2",
+                Name = "User 2",
+                ProfilePhoto = "u2.jpg",
+                UserType = BaseUserType.USER,
+                Location = new Point(1, 1) { SRID = 4326 }
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var (resultUser, error) = await service.PatchEmail(supabaseId, "new@email.com");
+
+        Assert.Null(resultUser);
+        Assert.Equal("El email ya está en uso.", error);
+    }
+
+    [Fact]
+    public async Task DeletePerfil_ShouldThrowException_WhenUserHasActiveExchanges()
+    {
+        await using var db = CreateDbContext();
+        var service = CreateService(db);
+        var userId = Guid.NewGuid();
+        var supabaseId = "user-with-active-exchange";
+        db.Users.Add(new BaseUser
+        {
+            Id = userId,
+            SupabaseId = supabaseId,
+            Email = "active@test.com",
+            Username = "active",
+            Name = "Active User",
+            ProfilePhoto = "active.jpg",
+            UserType = BaseUserType.USER,
+            Location = new Point(0, 0) { SRID = 4326 }
+        });
+
+        db.Matches.Add(new Match
+        {
+            Id = 10,
+            User1Id = userId,
+            User2Id = Guid.NewGuid(),
+            Status = MatchStatus.CHAT_CREATED,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        db.Exchanges.Add(new Exchange
+        {
+            ExchangeId = 20,
+            ChatId = 30,
+            MatchId = 10,
+            Status = ExchangeStatus.ACCEPTED,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.DeletePerfil(supabaseId));
+        Assert.Equal("No puedes borrar tu cuenta porque tienes intercambios en proceso.", ex.Message);
+    }
+}

--- a/Bookmerang.Tests/Helpers/DbSetMockHelper.cs
+++ b/Bookmerang.Tests/Helpers/DbSetMockHelper.cs
@@ -1,0 +1,133 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Bookmerang.Tests.Helpers
+{
+    public static class DbSetMockHelper
+    {
+        public static void SetSource<T>(this Mock<DbSet<T>> mockSet, IList<T> source) where T : class
+        {
+            var data = source.AsQueryable();
+
+            mockSet.As<IAsyncEnumerable<T>>()
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<T>(data.GetEnumerator()));
+
+            mockSet.As<IQueryable<T>>()
+                .Setup(m => m.Provider)
+                .Returns(new TestAsyncQueryProvider<T>(data.Provider));
+
+            mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
+            mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
+            mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
+        }
+    }
+
+    internal class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+    {
+        private readonly IQueryProvider _inner;
+
+        internal TestAsyncQueryProvider(IQueryProvider inner)
+        {
+            _inner = inner;
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            return new TestAsyncEnumerable<TEntity>(expression);
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            return new TestAsyncEnumerable<TElement>(expression);
+        }
+
+        public object Execute(Expression expression)
+        {
+            return _inner.Execute(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            return _inner.Execute<TResult>(expression);
+        }
+
+        public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        {
+            var resultType = typeof(TResult).GetGenericArguments()[0];
+            var executionResult = _inner.Execute(expression);
+
+            if (executionResult is IEnumerable<object> enumerableResult)
+            {
+                var list = Activator.CreateInstance(typeof(List<>).MakeGenericType(resultType));
+                var addMethod = list.GetType().GetMethod("Add");
+
+                foreach (var item in enumerableResult)
+                {
+                    addMethod.Invoke(list, new[] { item });
+                }
+
+                return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
+                    .MakeGenericMethod(list.GetType())
+                    .Invoke(null, new[] { list });
+            }
+
+            return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
+                .MakeGenericMethod(resultType)
+                .Invoke(null, new[] { executionResult });
+        }
+    }
+
+    internal class TestAsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestAsyncEnumerable(IEnumerable<T> enumerable)
+            : base(enumerable)
+        { }
+
+        public TestAsyncEnumerable(Expression expression)
+            : base(expression)
+        { }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
+
+        IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+    }
+
+    internal class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestAsyncEnumerator(IEnumerator<T> inner)
+        {
+            _inner = inner;
+        }
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            return new ValueTask<bool>(_inner.MoveNext());
+        }
+
+        public T Current => _inner.Current;
+
+        public ValueTask DisposeAsync()
+        {
+            _inner.Dispose();
+            return new ValueTask();
+        }
+    }
+}


### PR DESCRIPTION
tests unitarios para AuthController, cubriendo todos sus endpoints.
tests para AuthService, validando la lógica de negocio de autenticación.
DbSetMockHelper para facilitar la simulación de la base de datos en los tests.
La cobertura de los tests incluye casos de éxito y error en el registro, actualización y eliminación de perfiles.
Se comprueban escenarios como la existencia de usuarios o la eliminación de perfiles con intercambios activos.
Se ha asegurado el aislamiento de las pruebas utilizando Moq y una base de datos en memoria.