### PR TITLE
fix: arreglar borrado de bookdrops con intercambios vinculados

### DIFF
--- a/Bookmerang.Api/Controllers/Admin/AdminBookdropController.cs
+++ b/Bookmerang.Api/Controllers/Admin/AdminBookdropController.cs
@@ -24,7 +24,7 @@ public class AdminBookdropController(IBookdropService bookdropService) : Control
         var (found, error) = await _bookdropService.DeleteBookdrop(id);
 
         if (!found) return NotFound("Establecimiento no encontrado.");
-        if (error != null) return BadRequest(error);
+        if (error != null) return Conflict(new { error });
 
         return Ok(new { message = "Establecimiento eliminado correctamente." });
     }

--- a/Bookmerang.Api/Controllers/Bookdrop/BookdropController.cs
+++ b/Bookmerang.Api/Controllers/Bookdrop/BookdropController.cs
@@ -58,7 +58,7 @@ public class BookdropController(IBookdropService bookdropService, IBookDropExcha
         var (found, error) = await _bookdropService.DeleteBookdrop(targetId);
 
         if (!found) return NotFound("Establecimiento no encontrado.");
-        if (error != null) return BadRequest(error);
+        if (error != null) return Conflict(new { error });
 
         return Ok(new { message = "Establecimiento eliminado correctamente." });
     }

--- a/Bookmerang.Api/Services/Implementation/Bookdrop/BookdropService.cs
+++ b/Bookmerang.Api/Services/Implementation/Bookdrop/BookdropService.cs
@@ -1,5 +1,6 @@
 using Bookmerang.Api.Data;
 using Bookmerang.Api.Models.DTOs.Bookdrop;
+using Bookmerang.Api.Models.Enums;
 using Bookmerang.Api.Services.Interfaces.Bookdrop;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,6 +9,14 @@ namespace Bookmerang.Api.Services.Implementation.Bookdrop;
 public class BookdropService(AppDbContext db) : IBookdropService
 {
     private readonly AppDbContext _db = db;
+
+    private static readonly ExchangeStatus[] ActiveExchangeStatuses =
+    [
+        ExchangeStatus.NEGOTIATING,
+        ExchangeStatus.ACCEPTED_BY_1,
+        ExchangeStatus.ACCEPTED_BY_2,
+        ExchangeStatus.ACCEPTED
+    ];
 
     public async Task<BookdropProfileDto?> GetPerfil(string supabaseId)
     {
@@ -124,6 +133,18 @@ public class BookdropService(AppDbContext db) : IBookdropService
         try
         {
             var bookspot = bookdropUser.Bookspot;
+
+            // Intercambios asociados al bookspot: error si hay activos, desvincular los finalizados (quitar bookspot_id)
+            var meetings = await _db.ExchangeMeetings
+                .Include(m => m.Exchange)
+                .Where(m => m.BookspotId == bookspot.Id)
+                .ToListAsync();
+
+            if (meetings.Any(m => ActiveExchangeStatuses.Contains(m.Exchange.Status)))
+                return (true, "No se puede eliminar el establecimiento porque tiene intercambios activos.");
+
+            foreach (var meeting in meetings)
+                meeting.BookspotId = null;
 
             // Eliminar validaciones del bookspot
             var validations = await _db.BookspotValidations

--- a/Bookmerang.Tests/Bookdrop/BookdropServiceTests.cs
+++ b/Bookmerang.Tests/Bookdrop/BookdropServiceTests.cs
@@ -1,4 +1,5 @@
 using Bookmerang.Api.Data;
+using Bookmerang.Api.Models.Entities;
 using Bookmerang.Api.Models.Enums;
 using Bookmerang.Api.Services.Implementation.Auth;
 using Bookmerang.Api.Services.Implementation.Bookdrop;
@@ -11,6 +12,7 @@ using NetTopologySuite.Geometries;
 using Xunit;
 using System.IdentityModel.Tokens.Jwt;
 using Bookmerang.Api.Models.DTOs.Bookdrop;
+using MatchEntity = Bookmerang.Api.Models.Entities.Match;
 
 namespace Bookmerang.Tests.Bookdrop;
 
@@ -356,5 +358,72 @@ public class BookdropServiceTests(PostgresFixture fixture) : IClassFixture<Postg
 
         Assert.False(found);
         Assert.Null(error);
+    }
+
+    // ===== Eliminar bookdrop con intercambio activo =====
+
+    [Fact]
+    public async Task DeleteBookdrop_WithActiveExchange_ReturnsConflictAndKeepsData()
+    {
+        await using var db = _fixture.CreateDbContext();
+        var authService = CreateAuthService(db);
+        var bookdropService = CreateBookdropService(db);
+
+        var (usuario, _, _) = await authService.RegisterBusiness(
+            "delete_active@test.com", "Test1234", "delete_active", "Delete Active",
+            null, CreateLocation(), "Local Active", "Calle Active 1");
+
+        var userId = usuario!.Id;
+        var bookspotId = (await db.BookdropUsers.FindAsync(userId))!.BookSpotId;
+
+        // Exchange ACCEPTED (activo) entre dos usuarios regulares, en el bookspot del bookdrop
+        var u1 = await TestSeedHelper.SeedUser(db, "active_u1");
+        var u2 = await TestSeedHelper.SeedUser(db, "active_u2");
+
+        var book1 = new Book { OwnerId = u1, Status = BookStatus.PUBLISHED, Titulo = "Libro 1" };
+        var book2 = new Book { OwnerId = u2, Status = BookStatus.PUBLISHED, Titulo = "Libro 2" };
+        db.Books.AddRange(book1, book2);
+        await db.SaveChangesAsync();
+
+        var match = new MatchEntity
+        {
+            User1Id = u1, User2Id = u2,
+            Book1Id = book1.Id, Book2Id = book2.Id,
+            Status = MatchStatus.CHAT_CREATED, CreatedAt = DateTime.UtcNow
+        };
+        db.Matches.Add(match);
+        var chat = new Chat { Type = ChatType.EXCHANGE, CreatedAt = DateTime.UtcNow };
+        db.Chats.Add(chat);
+        await db.SaveChangesAsync();
+
+        var exchange = new Exchange { ChatId = chat.Id, MatchId = match.Id, Status = ExchangeStatus.ACCEPTED };
+        db.Exchanges.Add(exchange);
+        await db.SaveChangesAsync();
+
+        var meeting = new ExchangeMeeting
+        {
+            ExchangeId = exchange.ExchangeId,
+            ExchangeMode = ExchangeMode.BOOKDROP,
+            BookspotId = bookspotId,
+            CustomLocation = new Point(-5.98, 37.39) { SRID = 4326 },
+            ProposerId = u1,
+            MeetingStatus = ExchangeMeetingStatus.ACCEPTED,
+            BookDropStatus = BookdropExchangeStatus.AWAITING_DROP_1,
+            ScheduledAt = DateTime.UtcNow.AddHours(1)
+        };
+        db.ExchangeMeetings.Add(meeting);
+        await db.SaveChangesAsync();
+
+        var (found, error) = await bookdropService.DeleteBookdrop(userId);
+
+        Assert.True(found);
+        Assert.Equal("No se puede eliminar el establecimiento porque tiene intercambios activos.", error);
+
+        // Nada se ha borrado ni desvinculado
+        Assert.NotNull(await db.Users.FindAsync(userId));
+        Assert.NotNull(await db.BookdropUsers.FindAsync(userId));
+        Assert.NotNull(await db.Bookspots.FindAsync(bookspotId));
+        var meetingAfter = await db.ExchangeMeetings.FindAsync(meeting.ExchangeMeetingId);
+        Assert.Equal(bookspotId, meetingAfter!.BookspotId);
     }
 }


### PR DESCRIPTION

Se actualiza el borrado de bookdrops para solucionar problemas de borrados en cascada. Antes, al no existir todavía intercambios, el borrado estaba planteado para eliminar bookdrops sin exchange_meetings. Por eso al implementar el intercambio por bookdrop falla el borrado porque salta una integridad referencial.

Como solución, se implementa lo siguiente: Si el bookdrop no tiene todavía ningún exchange_meeting relacionado, se puede borrar, si no, da un 409 que imprime el frontend. En caso de que tenga intercambios vinculados todos finalizados, entonces se puede borrar y lo que se hace es desvincular el exchange_meeting poniendo el bookspot_id a nulo. Se añade una prueba que verifica el funcionamiento.

A tener en cuenta a futuro, es que si se elimina un bookdrop los intercambios asociados finalizados tienen el bookspot con nombre "sin identificar". Se podría poner un nombre más relacionado cuando se haga cualquier tarea relacionada en frontend.