### PR TITLE
fix(meetups): ordenar por fecha de creación y reset secuencias

### DIFF
--- a/Bookmerang.Api/Services/Implementation/Communities/MeetupService.cs
+++ b/Bookmerang.Api/Services/Implementation/Communities/MeetupService.cs
@@ -173,7 +173,7 @@ public class MeetupService(AppDbContext db, IValidator<CreateMeetupRequest> crea
                 .ThenInclude(u => u.BaseUser)
             .Include(m => m.Attendances)
                 .ThenInclude(a => a.SelectedBook)
-            .OrderBy(m => m.ScheduledAt)
+            .OrderByDescending(m => m.CreatedAt)
             .ToListAsync();
 
         var allAttendeeIds = meetups

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1019,4 +1019,11 @@ ON CONFLICT DO NOTHING;
 
 END $$;
 
+SELECT setval(pg_get_serial_sequence('meetups', 'id'), COALESCE((SELECT MAX(id) FROM meetups), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('communities', 'id'), COALESCE((SELECT MAX(id) FROM communities), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('books', 'id'), COALESCE((SELECT MAX(id) FROM books), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('bookspots', 'id'), COALESCE((SELECT MAX(id) FROM bookspots), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('matches', 'id'), COALESCE((SELECT MAX(id) FROM matches), 0) + 1, false);
+SELECT setval(pg_get_serial_sequence('exchanges', 'id'), COALESCE((SELECT MAX(id) FROM exchanges), 0) + 1, false);
+
 COMMIT;


### PR DESCRIPTION
- Ordenar meetups por CreatedAt descendente en lugar de ScheduledAt.
- Añadir reset de secuencias en seed.sql para evitar colisiones en DB (error 500).