### PR TITLE
fix(matcher): límite de swipes actualizado y lógica de match actualizada (sin repeticiones)

### DIFF
--- a/Bookmerang.Api/Program.cs
+++ b/Bookmerang.Api/Program.cs
@@ -133,7 +133,7 @@ builder.Services.AddRateLimiter(options =>
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier") ?? "anon";
         return RateLimitPartition.GetSlidingWindowLimiter(userId, _ => new SlidingWindowRateLimiterOptions
         {
-            PermitLimit = 30,          // 30 swipes
+            PermitLimit = 60,          // 60 swipes (1 por segundo)
             Window = TimeSpan.FromMinutes(1), // por minuto
             SegmentsPerWindow = 6,     // ventanas de 10 s
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,

--- a/Bookmerang.Api/Services/Implementation/Matcher/MatcherService.cs
+++ b/Bookmerang.Api/Services/Implementation/Matcher/MatcherService.cs
@@ -485,10 +485,12 @@ public class MatcherService(AppDbContext db, IOptions<MatcherSettings> settings,
 
     /// <summary>
     /// Filtros base compartidos por P1 y P2: status PUBLISHED, no propios,
-    /// no swipeados ya y dentro del radio del usuario.
+    /// no swipeados ya (en los últimos SwipeValidDays) y dentro del radio del usuario.
     /// </summary>
     private IQueryable<Book> GetBaseCandidates(Guid userId, UserPreference prefs)
     {
+        var cutoff = DateTime.UtcNow.AddDays(-_settings.Feed.SwipeValidDays);
+        
         var matchedBookIds = _db.Exchanges
             .Where(e => e.Status != ExchangeStatus.COMPLETED)
             .Where(e => e.Status != ExchangeStatus.REJECTED)
@@ -503,7 +505,7 @@ public class MatcherService(AppDbContext db, IOptions<MatcherSettings> settings,
             .Where(b => !_db.Matches.Any(m =>
                 (m.User1Id == userId && m.User2Id == b.OwnerId && m.Book2Id == b.Id)
                 || (m.User1Id == b.OwnerId && m.User2Id == userId && m.Book1Id == b.Id)))
-            .Where(b => !_db.Swipes.Any(s => s.SwiperId == userId && s.BookId == b.Id))
+            .Where(b => !_db.Swipes.Any(s => s.SwiperId == userId && s.BookId == b.Id && s.CreatedAt >= cutoff))
             .Where(b => _db.Users
                 .Any(bu => bu.Id == b.OwnerId
                     && bu.Location.IsWithinDistance(prefs.Location, prefs.RadioKm * 1000.0)));

--- a/Bookmerang.Api/Services/Implementation/Matcher/SwipeCleanupHostedService.cs
+++ b/Bookmerang.Api/Services/Implementation/Matcher/SwipeCleanupHostedService.cs
@@ -66,7 +66,14 @@ public class SwipeCleanupHostedService(
         using var scope = _serviceProvider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-        var deleted = await db.Swipes.ExecuteDeleteAsync(cancellationToken);
-        _logger.LogInformation("[SWIPE-CLEANUP] Deleted {DeletedCount} swipes.", deleted);
+        // Solo borrar swipes más antiguos que SwipeValidDays para evitar perder el historial
+        // de libros ya vistos (lo que permite filtrarlos del feed) mientras estén dentro de la ventana de validez
+        var cutoff = DateTime.UtcNow.AddDays(-_feedSettings.SwipeValidDays);
+        var deleted = await db.Swipes
+            .Where(s => s.CreatedAt < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+        
+        _logger.LogInformation("[SWIPE-CLEANUP] Deleted {DeletedCount} old swipes (older than {CutoffDays} days).", 
+            deleted, _feedSettings.SwipeValidDays);
     }
 }


### PR DESCRIPTION
Refs: #172

Actualizado el número de swipes por minuto a 60 y eliminados los libros recientes repetidos en matcher