### PR TITLE
fix: eliminar incidents e incident_status del sistema

### DIFF
--- a/Bookmerang.Api/Services/Implementation/Auth/AuthService.cs
+++ b/Bookmerang.Api/Services/Implementation/Auth/AuthService.cs
@@ -507,7 +507,7 @@ public async Task<(BaseUser? usuario, string? error)> PatchEmail(string supabase
         {
             await _db.Database.ExecuteSqlRawAsync("DELETE FROM points_ledgers WHERE user_id = {0}", userId);
             await _db.Database.ExecuteSqlRawAsync("DELETE FROM community_monthly_scores WHERE user_id = {0}", userId);
-            await _db.Database.ExecuteSqlRawAsync("DELETE FROM incidents WHERE informer_id = {0} OR informed_id = {0} OR admin_id = {0}", userId);
+
             await _db.Database.ExecuteSqlRawAsync("DELETE FROM admins WHERE id = {0}", userId);
         }
 

--- a/supabase/migrations/20260506000001_0015_drop_incidents.sql
+++ b/supabase/migrations/20260506000001_0015_drop_incidents.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS incidents;
+DROP TYPE IF EXISTS incident_status;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -989,9 +989,6 @@ SET pin = '123456',
     bookdrop_status = 'AWAITING_DROP_1'::bookdrop_exchange_status
 WHERE exchange_id = 15;
 
-INSERT INTO incidents (exchange_id, meetup_id, informer_id, informed_id, admin_id, comment, status, created_at) VALUES
-  (7, 3, u13, u10, '00000000-0000-0000-0000-0000000000a1'::uuid, 'El usuario no se presento en el punto acordado.', 'PENDING', now_ts - INTERVAL '10 hours')
-ON CONFLICT DO NOTHING;
 
 -- 16.9 Typing indicators para probar /typing en chats
 INSERT INTO typing_indicators (chat_id, user_id, started_at) VALUES


### PR DESCRIPTION
Se elimina incidents del sistema porque parece que no se usa en ningún lado y se elimina el 500. Más info en la tarea. 

Refs: #176 